### PR TITLE
Allow any number of leading zeros in rgb and rgba colour expressions

### DIFF
--- a/ebutt_datatypes.xsd
+++ b/ebutt_datatypes.xsd
@@ -104,11 +104,6 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 			</xs:simpleType>
 		</xs:union>
 	</xs:simpleType>
-	<xs:simpleType name="colorType">
-		<xs:union
-			memberTypes="ebuttdt:rgbHexColorType ebuttdt:rgbaHexColorType ebuttdt:rgbColorType ebuttdt:rgbaColorType ebuttdt:namedColorType"
-		/>
-	</xs:simpleType>
 	<xs:simpleType name="cellOriginType">
 		<xs:restriction base="xs:token">
 			<xs:pattern value="([+-]?\d*\.?\d+(c))\s([+-]?\d*\.?\d+(c))"/>
@@ -200,6 +195,11 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 			memberTypes="ebuttdt:cellLengthType ebuttdt:percentageLengthType ebuttdt:pixelLengthType"
 		/>
 	</xs:simpleType>
+	<xs:simpleType name="colorType">
+		<xs:union
+			memberTypes="ebuttdt:rgbHexColorType ebuttdt:rgbaHexColorType ebuttdt:rgbColorType ebuttdt:rgbaColorType ebuttdt:namedColorType"
+		/>
+	</xs:simpleType>
 	<xs:simpleType name="rgbHexColorType">
 		<xs:restriction base="xs:string">
 			<xs:pattern value="#[a-fA-F\d]{6}"/>
@@ -212,12 +212,12 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 	</xs:simpleType>
 	<xs:simpleType name="rgbColorType">
 		<xs:restriction base="xs:token">
-			<xs:pattern value="rgb\(([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5]),\s?([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5]),\s?([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])\)"/>
+			<xs:pattern value="rgb\(0*([1]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5]),\s?0*([1]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5]),\s?0*([1]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])\)"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="rgbaColorType">
 		<xs:restriction base="xs:token">
-			<xs:pattern value="rgba\(([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5]),\s?([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5]),\s?([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5]),\s?([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])\)"/>
+			<xs:pattern value="rgba\(0*([1]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5]),\s?0*([1]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5]),\s?0*([1]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5]),\s?0*([1]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])\)"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="namedColorType">


### PR DESCRIPTION
Also move the `colorType` definition to just before its union parts.

Closes #4.