### PR TITLE
Issue 0017 remove duplicate datatypes

### DIFF
--- a/ebutt_datatypes.xsd
+++ b/ebutt_datatypes.xsd
@@ -9,6 +9,7 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ebuttdt="urn:ebu:tt:datatypes"
 	targetNamespace="urn:ebu:tt:datatypes"
     xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1">
+	<xs:include schemaLocation="ebu-tt-m-xsd/ebu-tt-datatypes.xsd"/>
 	<xs:simpleType name="cellResolutionType">
 		<xs:restriction base="xs:token">
 			<xs:pattern value="[0]*[1-9][0-9]*\s[0]*[1-9][0-9]*"/>
@@ -38,47 +39,6 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 		<xs:union
 			memberTypes="ebuttdt:cellExtentType ebuttdt:percentageExtentType ebuttdt:pixelExtentType"
 		/>
-	</xs:simpleType>
-	<xs:simpleType name="fontFamilyType">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:simpleType name="cellFontSizeType">
-		<xs:restriction base="xs:token">
-			<xs:pattern
-				value="([+]?\d*\.?\d+(c))(\s([+]?\d*\.?\d+(c)))?"
-			/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="percentageFontSizeType">
-		<xs:restriction base="xs:token">
-			<xs:pattern
-				value="([+]?\d*\.?\d+(%))(\s([+]?\d*\.?\d+(%)))?"
-			/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="pixelFontSizeType">
-		<xs:restriction base="xs:token">
-			<xs:pattern
-				value="([+]?\d*\.?\d+(px))(\s([+]?\d*\.?\d+(px)))?"
-			/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="fontSizeType">
-		<xs:union
-			memberTypes="ebuttdt:cellFontSizeType ebuttdt:percentageFontSizeType ebuttdt:pixelFontSizeType"
-		/>
-	</xs:simpleType>
-	<xs:simpleType name="fontStyleType">
-		<xs:restriction base="xs:token">
-			<xs:enumeration value="normal"/>
-			<xs:enumeration value="italic"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="fontWeightType">
-		<xs:restriction base="xs:token">
-			<xs:enumeration value="normal"/>
-			<xs:enumeration value="bold"/>
-		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="cellLineHeightType">
 		<xs:restriction base="xs:string">
@@ -144,40 +104,12 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 		<xs:union
 			memberTypes="ebuttdt:clockTimingType ebuttdt:mediaTimingType"/>
 	</xs:simpleType>
-	<xs:simpleType name="smpteTimingType">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="([0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]:[0-9][0-9]"/>
-		</xs:restriction>
-	</xs:simpleType>
 	<xs:simpleType name="clockTimingType">
 		<xs:union memberTypes="ebuttdt:limitedClockTimingType ebuttdt:timecountTimingType"/>
-	</xs:simpleType>
-	<xs:simpleType name="mediaTimingType">
-		<xs:union memberTypes="ebuttdt:timecountTimingType ebuttdt:fullClockTimingType"/>
-	</xs:simpleType>
-	<xs:simpleType name="timecountTimingType">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="[0-9]+(\.[0-9]+)?(h|ms|s|m)"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="authoringDelayType">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="[+-]?[0-9]+(\.[0-9]+)?(h|ms|s|m)"/>
-		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="limitedClockTimingType">
 		<xs:restriction base="xs:string">
 			<xs:pattern value="[0-9][0-9]:[0-5][0-9]:([0-5][0-9]|60)(\.[0-9]+)?"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="noTimezoneDateType">
-		<xs:restriction base="xs:date">
-			<xs:pattern value="[^:Z]*"/>
-		</xs:restriction>
-        </xs:simpleType>
-	<xs:simpleType name="fullClockTimingType">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="[0-9][0-9]+:[0-5][0-9]:([0-5][0-9]|60)(\.[0-9]+)?"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="cellLengthType">
@@ -244,16 +176,6 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 		</xs:restriction>
 	</xs:simpleType>
 
-	<xs:simpleType name="transitionStyleAttributeType">
-		<xs:restriction base="xs:token">
-			<xs:enumeration value="block"/>
-			<xs:enumeration value="line"/>
-			<xs:enumeration value="word"/>
-			<xs:enumeration value="partOfWord"/>
-			<xs:enumeration value="groupOfWords"/>
-		</xs:restriction>
-	</xs:simpleType>
-	
 	<xs:simpleType name="distributionMediaTimingType">
 		<xs:restriction base="xs:string">
 			<xs:pattern value="[0-9][0-9]+:[0-5][0-9]:([0-5][0-9]|[0-6][0])(\.[0-9]+)?"/>


### PR DESCRIPTION
Remove duplicate data type definitions

Some types are defined already in `ebu-tt-m-xsd/ebu-tt-datatypes.xsd`, so include those definitions and remove the duplication.

Closes #17 **when ebu/ebu-tt-m-xsd#28 has been merged and the submodule updated to point to it**

### Take care before merging

**Note** that this pull request updates the submodule commit, but that will need to be advanced further most likely, due to the high number of outstanding pull requests to be merged in ebu/ebu-tt-m-xsd, some of which will require updates to ebu/ebu-tt-m-xsd#28.